### PR TITLE
feat: bump tf requirement to 1.5; add checks

### DIFF
--- a/.github/workflows/terraform_docs.yml
+++ b/.github/workflows/terraform_docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: store hash of new README.md
       id: new_hash
       run: echo "README_HASH=$(md5sum README.md)" >> $GITHUB_OUTPUT
-    - name: echo hashes
+    - name: echo hashes 
       run: |
         echo ${{ steps.old_hash.outputs.README_HASH }}
         echo ${{ steps.new_hash.outputs.README_HASH }}

--- a/.github/workflows/terraform_docs.yml
+++ b/.github/workflows/terraform_docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: store hash of new README.md
       id: new_hash
       run: echo "README_HASH=$(md5sum README.md)" >> $GITHUB_OUTPUT
-    - name: echo hashes 
+    - name: echo hashes
       run: |
         echo ${{ steps.old_hash.outputs.README_HASH }}
         echo ${{ steps.new_hash.outputs.README_HASH }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ All code contributions made by Lacework customers to this repo are considered â€
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.45.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.77.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | >= 1.18 |

--- a/checks.tf
+++ b/checks.tf
@@ -1,0 +1,24 @@
+// Provides some guardrails for common misconfiguration
+// Those are only available after Terraform v1.5. 
+
+/* When we are doing a non-global/regional deployment, we expect some global resources 
+to have been created. One way to check that is to ensure we can reference them via
+the global_module_reference attribute.
+*/
+
+check "check_global_resource_condition" {
+  assert {
+    condition = var.global || (
+      length(var.global_module_reference.storage_account_id) > 0 &&
+      length(var.global_module_reference.scanning_subscription_role_definition_id) > 0 &&
+      length(var.global_module_reference.monitored_subscription_role_definition_id) > 0 &&
+      length(var.global_module_reference.blob_container_name) > 0 &&
+      length(var.global_module_reference.key_vault_id) > 0 &&
+      length(var.global_module_reference.sidekick_principal_id) > 0 &&
+      length(var.global_module_reference.sidekick_client_id) > 0 &&
+      length(var.global_module_reference.key_vault_secret_name) > 0 &&
+      length(var.global_module_reference.key_vault_uri) > 0
+    )
+    error_message = "Some resources have not been referenced correctly during a non-global deployment"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -129,30 +129,6 @@ locals {
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""
 }
 
-/* When we are doing a non-global/regional deployment, we expect some global resources 
-to have been created. One way to check that is to ensure we can reference them via
-the global_module_reference attribute.
-TODO: Unfortunately this wouldn't work because the `check` predicate is only supported after 
-TF 1.5 but we need to be backward compatible. We should uncomment this once Terraform major 
-version is upgraded.
-*/
-/* check "check_global_resource_condition" {
-  assert {
-    condition = var.global || (
-      length(var.global_module_reference.storage_account_id) > 0 &&
-      length(var.global_module_reference.scanning_subscription_role_definition_id) > 0 &&
-      length(var.global_module_reference.monitored_subscription_role_definition_id) > 0 &&
-      length(var.global_module_reference.blob_container_name) > 0 &&
-      length(var.global_module_reference.key_vault_id) > 0 &&
-      length(var.global_module_reference.sidekick_principal_id) > 0 &&
-      length(var.global_module_reference.sidekick_client_id) > 0 &&
-      length(var.global_module_reference.key_vault_secret_name) > 0 &&
-      length(var.global_module_reference.key_vault_uri) > 0
-    )
-    error_message = "Some resources have not been referenced correctly during a non-global deployment"
-  }
-}
- */
 resource "random_id" "uniq" {
   byte_length = 2
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This PR bumps the terraform version requirement to v1.5+. This way we are able to support usage of [`check` block ](https://developer.hashicorp.com/terraform/language/checks). 

I also uncommented some checks block and will start adding more guardrails to TF deployment.

## How did you test this change?

terraform apply 

## Issue

https://lacework.atlassian.net/browse/PSP-1963