### PR TITLE
fix: fix off by one validator condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "suffix" {
   default     = ""
 
   validation {
-    condition     = length(var.suffix) == 0 || length(var.suffix) > 4
+    condition     = length(var.suffix) == 0 || length(var.suffix) >= 4
     error_message = "If the suffix value is set then it must be at least 4 characters long."
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Ironically the suffix that we randomly create has 4 characters, so let's not restrict user inputs in an inconsistent way.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->