### PR TITLE
Update Az versions to make Azure TF deployment work

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,4 @@
 formatter: "markdown"
-version: "0.17.0"
+version: "0.16.0"
 output:
   file: README.md

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,4 @@
 formatter: "markdown"
-version: "0.16.0"
+version: "0.17.0"
 output:
   file: README.md

--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ All code contributions made by Lacework customers to this repo are considered â€
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.45.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.77.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 1.15.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.53.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | >= 1.18 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | n/a |
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.45.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.77.0 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 1.15.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.53.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116.0 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | >= 1.18 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "azurerm_storage_account" "scanning" {
   infrastructure_encryption_enabled = var.enable_storage_infrastructure_encryption
   allow_nested_items_to_be_public   = false
   min_tls_version                   = "TLS1_2"
-  enable_https_traffic_only         = true
+  https_traffic_only_enabled        = true
 
   tags = var.tags
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,15 +3,16 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.45.0"
+      version = "~> 2.53.1"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.77.0"
+      version = "~> 3.116.0"
     }
     // include azapi because Azure Container App Jobs isn't yet available as a provider
     azapi = {
       source = "Azure/azapi"
+      version = "~> 1.15.0"
     }
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Azure TF currently makes use of old versions of azuread, azurerm, azapi. This PR updates those to a newer version which works well.

## How did you test this change?

Tested that TF deployment works after the change.

## Issue

https://lacework.atlassian.net/browse/AWLS2-393
