### PR TITLE
AWLS2-353: azure cost estimation

### DIFF
--- a/custom_roles.tf
+++ b/custom_roles.tf
@@ -46,7 +46,7 @@ resource "azurerm_role_definition" "agentless_scanning_subscription" {
       "Microsoft.Compute/disks/write",
       "Microsoft.Compute/disks/read",
       "Microsoft.Compute/disks/delete",
-      "Microsoft.CostManagement/*/read", // new
+      "Microsoft.CostManagement/*/read", 
       "Microsoft.Network/locations/*",
       "Microsoft.Network/networkInterfaces/*",
       "Microsoft.Network/networkSecurityGroups/join/action",


### PR DESCRIPTION


## Summary

This PR adds cost management permissions to the agentless Azure scanning subscription role. This allows us to retrieve agentless cost data from customer environments.

I've tried to add the minimal set of permissions needed to accomplish this -- in particular, we are granting read permissions to the Cost Management API only within our scanning subscription.

This PR is a companion to these changes to the agentless scanner: https://github.com/lacework-dev/sidekick/pull/1225

## How did you test this change?
I deployed the agentless scanner changes above both with and without these Terraform  changes. Once I updated the role, I observed that we had sufficient permissions to retrieve cost data and the reported cost for our resource group matched what I saw in the Cost Explorer UI.

Before: https://ui.honeycomb.io/lacework/datasets/sidekick-dev/result/qdePCAMfQ6T/trace/mvb4TNiXHrp?fields[]=s_name&fields[]=s_serviceName&source=query&span=e2a1d9d41167ce2c

After: https://ui.honeycomb.io/lacework/datasets/sidekick-dev/result/teyDZ83Bqfo/trace/o7jSwEwN6RL?fields[]=s_name&fields[]=s_serviceName&source=query&span=f982583c5524206b

## Issue
https://lacework.atlassian.net/browse/AWLS2-353
