### PR TITLE
feat(AWLS2-444): update CI to use Terraform 1.9 as minimum version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,4 +10,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-nightly.yml@main
     secrets: inherit
     with:
-      tf-version: '["1.5"]'
+      tf-version: '["1.9"]'

--- a/.github/workflows/test-compat-pr-comment.yml
+++ b/.github/workflows/test-compat-pr-comment.yml
@@ -28,4 +28,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit
     with:
-      min-version: 1.5
+      min-version: 1.9

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -12,4 +12,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit
     with:
-      min-version: 1.5
+      min-version: 1.9


### PR DESCRIPTION
## Summary

Updates our CI to only validate against Terraform 1.9 and up. 

## How did you test this change?

This is self-testing -- if the CI runs green here and on https://github.com/lacework/terraform-azure-agentless-scanning/pull/43, then we are all set. 

## Issue
AWLS2-444