### PR TITLE
fix(AWLS2-456) Set tags in scanning resource group and log analytics …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,7 @@ resource "azurerm_resource_group" "scanning_rg" {
 
   name     = local.scanning_resource_group_name
   location = local.region
+  tags     = var.tags
 }
 
 data "azurerm_resource_group" "scanning_rg" {
@@ -528,6 +529,7 @@ resource "azurerm_log_analytics_workspace" "agentless_orchestrate" {
   name                = replace("${local.prefix}-log-${local.region}-${local.suffix}", " ", "-")
   location            = local.region
   resource_group_name = local.scanning_resource_group_name
+  tags                = var.tags
 }
 
 


### PR DESCRIPTION
…workspace

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Currently, tags specified while creating regional modules were getting set on resource group and log analytics workspace created as part of terraform apply. This PR fixes this, by setting the tags appropriately.

## How did you test this change?

Run terraform apply and verify the tags set on all the resources created by the terraform

## Issue

https://lacework.atlassian.net/browse/AWLS2-456
