### PR TITLE
Change default nat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ No modules.
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | A string to be appended to the end of the name of all new resources. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Set of tags which will be added to the resources managed by the module. | `map(string)` | `{}` | no |
 | <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | TenantId where LW Sidekick is deployed | `string` | `""` | no |
-| <a name="input_use_nat_gateway"></a> [use\_nat\_gateway](#input\_use\_nat\_gateway) | Whether to use a NAT gateway instead of public IPs on scanning instances. Defaults to `true`. | `bool` | `true` | no |
+| <a name="input_use_nat_gateway"></a> [use\_nat\_gateway](#input\_use\_nat\_gateway) | Whether to use a NAT gateway instead of public IPs on scanning instances. Defaults to `false`. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/custom-vnet/main.tf
+++ b/examples/custom-vnet/main.tf
@@ -60,11 +60,9 @@ module "lacework_azure_agentless_scanning_rg_and_vnet" {
   create_log_analytics_workspace = true
   region                         = local.region
 
-  // When using a custom vnet with the default NAT gateway (use_nat_gateway = true),
-  // you must specify the network security group here:
-  custom_network_security_group = azurerm_network_security_group.example.id
-  
-  // If you want to use public IPs instead of a NAT gateway, comment out the line above
-  // and uncomment this line:
-  // use_nat_gateway = false
+  // When using a custom vnet with the NAT gateway (use_nat_gateway = true),
+  // uncomment the two lines below and specify the network security group:
+
+  // use_nat_gateway = true
+  // custom_network_security_group = azurerm_network_security_group.example.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,8 @@ variable "tags" {
 
 variable "use_nat_gateway" {
   type        = bool
-  description = "Whether to use a NAT gateway instead of public IPs on scanning instances. Defaults to `true`."
-  default     = true
+  description = "Whether to use a NAT gateway instead of public IPs on scanning instances. Defaults to `false`."
+  default     = false
 }
 
 variable "custom_network" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This PR switches the `use_nat_gateway` variable to `false` by default instead of `true`. Internal tests revealed the cost impact of using NAT gateways to be higher than expected -- it will still be a viable approach for larger customers and customers with stringent network requirements, but we don't think it's the best option for most customers. 

## How did you test this change?
I will deploy a test Azure integration and confirm that a NAT gateway is no longer created in the default configuration.

## Issue
None.