### PR TITLE
fix(AWLS2-462): syntax issue in nightly CI runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,4 +10,4 @@ jobs:
     uses: lacework/oss-actions/.github/workflows/tf-nightly.yml@main
     secrets: inherit
     with:
-      tf-version: '["1.9"]'
+      tf-versions: '["1.9"]'


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This PR fixes the nightly runs in this repo. Some time back (> 9 months ago) the input syntax for the upstream `tf-nightly` job in  https://github.com/lacework/oss-actions changed. This PR updates our GitHub Action accordingly. 

## How did you test this change?
Proof that the nightly build now succeeds here: https://github.com/lacework/terraform-azure-agentless-scanning/actions/runs/12773126443

## Issue
https://lacework.atlassian.net/browse/AWLS2-462
