### PR TITLE
chore(terraform-docs): update terraform-docs script

### DIFF
--- a/scripts/terraform-docs.sh
+++ b/scripts/terraform-docs.sh
@@ -1,11 +1,10 @@
-
 if which terraform-docs >/dev/null; then
     terraform-docs .
 elif which docker >/dev/null; then
     echo "## terraform-docs not found in PATH, but docker was found"
     echo "## running terraform-docs in docker"
     terraform_docs_version=$(cat .terraform-docs.yml | grep version | cut -d\" -f 2)
-    docker run --rm -v `pwd`:/data cytopia/terraform-docs:${terraform_docs_version} terraform-docs .
+    docker run --rm -v `pwd`:/data quay.io/terraform-docs/terraform-docs:${terraform_docs_version} markdown ./data
 else
     echo "## terraform-docs not found in PATH, neither was docker"
     echo "## please install terraform-docs or docker"


### PR DESCRIPTION
## Summary

I was unable to run terraform-docs using the existing script, so I made the following modifications:
1. Updated to pull terraform-docs image from `quay.io/terraform-docs/terraform-docs`, not `cytopia/terraform-docs`.
2. Updated the `docker run` command to run `terraform-docs` with the `markdown` command pointed to the `data` mounted directory.

## How did you test this change?

I successfully ran `make terraform-docs`.

## Issue

N/A