### PR TITLE
fix(custom-vnet): set proper resource name for nsg in custom-vnet example

### DIFF
--- a/examples/custom-vnet/README.md
+++ b/examples/custom-vnet/README.md
@@ -46,7 +46,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 /* Ensure the subnet allows egress traffic on port 443 or the scanner will break */
-resource "azurerm_network_security_group" "lw" {
+resource "azurerm_network_security_group" "example" {
   depends_on          = [azurerm_resource_group.example]
   name                = "example-nsg"
   location            = local.region
@@ -66,7 +66,7 @@ resource "azurerm_network_security_group" "lw" {
 }
 
 resource "azurerm_virtual_network" "example" {
-  depends_on          = [azurerm_network_security_group.lw]
+  depends_on          = [azurerm_network_security_group.example]
   name                = "example-vnet"
   address_space       = ["10.0.0.0/16"]
   location            = local.region
@@ -75,7 +75,7 @@ resource "azurerm_virtual_network" "example" {
   subnet {
     name           = "example-subnet"
     address_prefix = "10.0.0.0/16"
-    security_group = azurerm_network_security_group.lw.id
+    security_group = azurerm_network_security_group.example.id
   }
 }
 
@@ -89,7 +89,8 @@ module "lacework_azure_agentless_scanning_rg_and_vnet" {
   custom_network                 = tolist(azurerm_virtual_network.example.subnet)[0].id
   create_log_analytics_workspace = true
   region                         = local.region
+  custom_network_security_group  = azurerm_network_security_group.example.id
   scanning_subscription_id       = "abcd-1234"
-  tenant_id                      = "efgh-5678"
+  tenant_id                      = "efgh-5678"  
 }
 ```

--- a/examples/custom-vnet/main.tf
+++ b/examples/custom-vnet/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_network_security_group" "example" {
 }
 
 resource "azurerm_virtual_network" "example" {
-  depends_on          = [azurerm_network_security_group.lw]
+  depends_on          = [azurerm_network_security_group.example]
   name                = "example-vnet"
   address_space       = ["10.0.0.0/16"]
   location            = local.region
@@ -43,7 +43,7 @@ resource "azurerm_virtual_network" "example" {
   subnet {
     name           = "example-subnet"
     address_prefix = "10.0.0.0/16"
-    security_group = azurerm_network_security_group.lw.id
+    security_group = azurerm_network_security_group.example.id
   }
 }
 


### PR DESCRIPTION
## Summary

The `custom-vnet` example had a minor bug: it creates an NSG (`azurerm_network_security_group`) with the resource name `example`, but the `azurerm_virtual_network` resource definition references the NSG with the resource name `lw`.

## How did you test this change?

I successfully created and destroyed an Azure AWLS integration using the example tf script in `examples/custom-vnet`. I did this for both NAT gateway and public IP use cases (`use_nat_gateway = true` and `use_nat_gateway = false`, respectively).

## Issue

N/A