### PR TITLE
docs: add instructions for deleting orphaned scanning VMs

### DIFF
--- a/preflight_check/README.md
+++ b/preflight_check/README.md
@@ -119,6 +119,7 @@ In the following steps, we will assign the necessary permissions to this service
             "Microsoft.Authorization/roleAssignments/*",
             "Microsoft.Authorization/roleDefinitions/*",
             "Microsoft.Compute/virtualMachines/read",
+            "Microsoft.Compute/virtualMachines/delete",
             "Microsoft.Compute/virtualMachineScaleSets/read",
             "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
             "Microsoft.KeyVault/vaults/*",


### PR DESCRIPTION
## Summary

If AWLS is deprovisioned while a scan is in progress, any existing scanning VMs will remain and cannot be deleted by terraform because they are dynamically created by sidekick. In this case, `terraform destroy` will fail to delete a subnet it created (because the subnet is still in use by the orphaned scanning VMs) and error out.

To resolve this, the scanning VMs must be deleted before re-running `terraform destroy`. I've added a note in the README to explain this and guide users through the resolution. I also updated the scanning subscription permissions to allow the deployment service princpal to delete VMs as is required.

## How did you test this change?

I verified that running the command indeed deleted the scanning VMs, and successfully ran `terraform destroy` when it was previously failing due to this issue.

## Issue

[AWLS2-396](https://lacework.atlassian.net/browse/AWLS2-396)

[AWLS2-396]: https://lacework.atlassian.net/browse/AWLS2-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ