### PR TITLE
chore: replace local exec with azapi action

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ All code contributions made by Lacework customers to this repo are considered â€
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.37 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
@@ -60,6 +59,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azapi_resource.container_app_job_agentless](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) | resource |
+| [azapi_resource_action.job_execution_now](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) | resource |
 | [azuread_application.lw](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_service_principal.data_loader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.data_loader](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
@@ -91,7 +91,6 @@ No modules.
 | [azurerm_virtual_network.agentless_orchestrate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [lacework_integration_azure_agentless_scanning.lacework_cloud_account](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_azure_agentless_scanning) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [terraform_data.job_execution_now](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [time_sleep.wait_for_role_assignment_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.scanning_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/main.tf
+++ b/main.tf
@@ -625,16 +625,13 @@ resource "azapi_resource" "container_app_job_agentless" {
 }
 
 # Trigger execution, if requested
-resource "terraform_data" "job_execution_now" {
-  count = var.execute_now && var.regional ? 1 : 0
-
-  provisioner "local-exec" {
-    command = "az containerapp job start --name ${azapi_resource.container_app_job_agentless[0].name} --resource-group ${local.scanning_resource_group_name}"
-  }
-
-  triggers_replace = {
-    always_run = timestamp()
-  }
+resource "azapi_resource_action" "job_execution_now" {
+  count       = var.execute_now && var.regional ? 1 : 0
+  type        = "Microsoft.App/jobs@2023-05-01"
+  resource_id = azapi_resource.container_app_job_agentless[0].id
+  action      = "start"
+  method      = "POST"
+  response_export_values = ["*"]
 
   depends_on = [azapi_resource.container_app_job_agentless]
 }

--- a/main.tf
+++ b/main.tf
@@ -633,6 +633,11 @@ resource "azapi_resource_action" "job_execution_now" {
   method      = "POST"
   response_export_values = ["*"]
 
+  body = jsonencode({
+    # Add a dynamic field to force re-creation on every apply
+    trigger = timestamp()
+  })
+
   depends_on = [azapi_resource.container_app_job_agentless]
 }
 


### PR DESCRIPTION
## Summary

Replace local exec with azapi action.

Starting container app job instantly using Azure api instead of Azure cli.

This change eliminates the need to install and authenticate azure cli, which helps when executing this tf module in CI.

## How did you test this change?

* Run successful in devspace. 
* Can see that job executed in AZ portal
<img width="1775" height="394" alt="Screenshot 2025-07-31 at 1 53 04 PM" src="https://github.com/user-attachments/assets/6f46b901-de16-4769-b778-a17dfddc730d" />

* On every terraform apply
<img width="976" height="282" alt="Screenshot 2025-08-01 at 3 25 40 PM" src="https://github.com/user-attachments/assets/38e806e1-6e11-4613-9ab7-463957992f0f" />
<img width="976" height="282" alt="Screenshot 2025-08-01 at 3 26 51 PM" src="https://github.com/user-attachments/assets/865dce15-5b2a-42e0-919a-3a819400fdf5" />



We can see runs in az portal
<img width="1318" height="717" alt="Screenshot 2025-08-01 at 3 25 01 PM" src="https://github.com/user-attachments/assets/29fce097-19c6-4193-b6d9-b2b99739ac2d" />
<img width="1206" height="280" alt="Screenshot 2025-08-01 at 3 28 13 PM" src="https://github.com/user-attachments/assets/f8da98a2-6b08-42df-bafb-c6fa41caf14d" />


## Issue

<!--
  Include the link to a Jira/Github issue
-->