### PR TITLE
fix: Update examples

### DIFF
--- a/examples/custom-vnet/README.md
+++ b/examples/custom-vnet/README.md
@@ -74,7 +74,7 @@ resource "azurerm_virtual_network" "example" {
 
   subnet {
     name           = "example-subnet"
-    address_prefix = "10.0.0.0/16"
+    address_prefixes = ["10.0.0.0/16"]
     security_group = azurerm_network_security_group.example.id
   }
 }

--- a/examples/custom-vnet/README.md
+++ b/examples/custom-vnet/README.md
@@ -84,6 +84,10 @@ resource "azurerm_virtual_network" "example" {
 module "lacework_azure_agentless_scanning_rg_and_vnet" {
   source = "lacework/agentless-scanning/azure"
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "TENANT"
   global                         = true
   custom_network                 = tolist(azurerm_virtual_network.example.subnet)[0].id

--- a/examples/custom-vnet/main.tf
+++ b/examples/custom-vnet/main.tf
@@ -41,9 +41,9 @@ resource "azurerm_virtual_network" "example" {
   resource_group_name = azurerm_resource_group.example.name
 
   subnet {
-    name           = "example-subnet"
-    address_prefix = "10.0.0.0/16"
-    security_group = azurerm_network_security_group.example.id
+    name             = "example-subnet"
+    address_prefixes = ["10.0.0.0/16"]
+    security_group   = azurerm_network_security_group.example.id
   }
 }
 

--- a/examples/custom-vnet/main.tf
+++ b/examples/custom-vnet/main.tf
@@ -54,6 +54,10 @@ this to succeed. */
 module "lacework_azure_agentless_scanning_rg_and_vnet" {
   source = "../.."
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "TENANT"
   global                         = true
   custom_network                 = tolist(azurerm_virtual_network.example.subnet)[0].id

--- a/examples/subscription-multi-region/README.md
+++ b/examples/subscription-multi-region/README.md
@@ -23,6 +23,10 @@ terraform {
 module "lacework_azure_agentless_scanning_subscription_us_west" {
   source = "lacework/agentless-scanning/azure"
 
+  # Replace with your Lacework account name.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "SUBSCRIPTION"
   global                         = true
   create_log_analytics_workspace = true

--- a/examples/subscription-multi-region/README.md
+++ b/examples/subscription-multi-region/README.md
@@ -23,7 +23,7 @@ terraform {
 module "lacework_azure_agentless_scanning_subscription_us_west" {
   source = "lacework/agentless-scanning/azure"
 
-  # Replace with your Lacework account name.
+  # Specify your Lacework account name - only specify this in the global module.
   # For example, 'my-org' is the account name in 'my-org.lacework.net'.
   lacework_account = "my-org"
 

--- a/examples/subscription-multi-region/main.tf
+++ b/examples/subscription-multi-region/main.tf
@@ -3,6 +3,10 @@
 module "lacework_azure_agentless_scanning_subscription_us_west" {
   source = "../.."
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "SUBSCRIPTION"
   global                         = true
   create_log_analytics_workspace = true

--- a/examples/subscription-single-region/README.md
+++ b/examples/subscription-single-region/README.md
@@ -21,12 +21,14 @@ terraform {
 module "lacework_azure_agentless_scanning_subscription_us_west" {
   source = "lacework/agentless-scanning/azure"
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "SUBSCRIPTION"
   global                         = true
   create_log_analytics_workspace = true
   region                         = "West US"
-  scanning_subscription_id       = "abcd-1234"
-  tenant_id                      = "efgh-5678"
   // specify which subscriptions to monitor - only do this in the global module
   included_subscriptions         = ["/subscriptions/subscription-1", "/subscriptions/subscription-2"]
 }

--- a/examples/subscription-single-region/main.tf
+++ b/examples/subscription-single-region/main.tf
@@ -2,9 +2,14 @@
 module "lacework_azure_agentless_scanning_subscription_us_west" {
   source = "../.."
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "SUBSCRIPTION"
   global                         = true
   create_log_analytics_workspace = true
   region                         = "West US"
+  // specify which subscriptions to monitor - only do this in the global module
   included_subscriptions         = ["/subscriptions/subscription-1", "/subscriptions/subscription-2"]
 }

--- a/examples/tenant-multi-region/README.md
+++ b/examples/tenant-multi-region/README.md
@@ -33,6 +33,10 @@ terraform {
 module "lacework_azure_agentless_scanning_tenant_us_west" {
   source = "lacework/agentless-scanning/azure"
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "TENANT"
   global                         = true
   create_log_analytics_workspace = true

--- a/examples/tenant-multi-region/main.tf
+++ b/examples/tenant-multi-region/main.tf
@@ -3,6 +3,10 @@
 module "lacework_azure_agentless_scanning_tenant_us_west" {
   source = "../.."
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   integration_level              = "TENANT"
   global                         = true
   create_log_analytics_workspace = true

--- a/examples/tenant-single-region/README.md
+++ b/examples/tenant-single-region/README.md
@@ -27,9 +27,14 @@ provider "lacework" {}
 module "lacework_azure_agentless_scanning_single_tenant" {
   source = "lacework/agentless-scanning/azure"
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   global                         = true
   create_log_analytics_workspace = true
   integration_level              = "tenant"
+  region                         = "West US"
   tags                           = { "lw-example-tf" : "true" }
   scanning_subscription_id       = "abcd-1234"
   tenant_id                      = "efgh-5678"

--- a/examples/tenant-single-region/main.tf
+++ b/examples/tenant-single-region/main.tf
@@ -5,9 +5,15 @@ provider "lacework" {}
 module "lacework_azure_agentless_scanning_single_tenant" {
   source = "../.."
 
+  # Specify your Lacework account name - only specify this in the global module.
+  # For example, 'my-org' is the account name in 'my-org.lacework.net'.
+  lacework_account = "my-org"
+
   global                         = true
   create_log_analytics_workspace = true
   integration_level              = "tenant"
+  region                         = "West US"
   tags                           = { "lw-example-tf" : "true" }
-  additional_environment_variables = [{name="EXAMPLE_ENV_VAR", value="some_value"}]
+  scanning_subscription_id       = "abcd-1234"
+  tenant_id                      = "efgh-5678"
 }

--- a/examples/tenant-single-region/main.tf
+++ b/examples/tenant-single-region/main.tf
@@ -14,6 +14,4 @@ module "lacework_azure_agentless_scanning_single_tenant" {
   integration_level              = "tenant"
   region                         = "West US"
   tags                           = { "lw-example-tf" : "true" }
-  scanning_subscription_id       = "abcd-1234"
-  tenant_id                      = "efgh-5678"
 }


### PR DESCRIPTION
## Summary

Fixes small errors in the examples:
1. In all examples, the global module should have `lacework_account` specified. This is not a required variable, but the default value (`""`) doesn't make sense here.
2. In the `tenant-single-region` example, the module is missing the `region` attribute. By default, this causes AWLS to be deployed in `US West 2`.
3. In the `custom-vnet` example, the vnet resource should have `subnet.address_prefixes` (list[str]) instead of `subnet.address_prefix` (str).

## How did you test this change?
Changes 1 and 2 match our internal deployments. No functional changes here, just specifying explicit values instead of relying on defaults. 

For the `custom-vnet` changes, I successfully deployed the azure vnet on its own — it errored with the previous syntax.

## Issue

N/A