### PR TITLE
fix(LINK-4201): proper configuration of key vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ No modules.
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [terraform_data.job_execution_now](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.existing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.scanning_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_subscriptions.available](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscriptions) | data source |

--- a/main.tf
+++ b/main.tf
@@ -349,7 +349,7 @@ resource "azurerm_key_vault_secret" "lw_orchestrate" {
   count = var.global ? 1 : 0
   depends_on = [
     lacework_integration_azure_agentless_scanning.lacework_cloud_account,
-    azurerm_key_vault_access_policy.key_vault_user
+    azurerm_role_assignment.key_vault_user
   ]
 
   /* stores credentials used to authenticate to LW API server */

--- a/main.tf
+++ b/main.tf
@@ -120,11 +120,15 @@ locals {
   environment_variables_as_list =  concat([for key, val in local.environment_variables : { name = key, value = val }],
    [for obj in var.additional_environment_variables : { name = obj["name"], value = obj["value"] }])
 
-  key_vault_id = var.global ? azurerm_key_vault.lw_orchestrate[0].id : (
+  key_vault_id = var.global ? (
+    length(var.key_vault_id) > 0 ? var.key_vault_id : azurerm_key_vault.lw_orchestrate[0].id
+  ) : (
     length(var.global_module_reference.key_vault_id) > 0 ? var.global_module_reference.key_vault_id : var.key_vault_id
   )
   key_vault_secret_name = var.global ? "${local.prefix}-secret-${local.suffix}" : var.global_module_reference.key_vault_secret_name
-  key_vault_uri         = var.global ? azurerm_key_vault.lw_orchestrate[0].vault_uri : var.global_module_reference.key_vault_uri
+  key_vault_uri         = var.global ? (
+    length(var.key_vault_id) > 0 ? data.azurerm_key_vault.existing[0].vault_uri : azurerm_key_vault.lw_orchestrate[0].vault_uri
+  )  : var.global_module_reference.key_vault_uri
 
   /* role_definition_id created as part of azurerm_role_definition creation contains an extra '|' character in the end, which needs to be removed (using split) */
   monitored_subscription_role_definition_id = var.global ? split("|", azurerm_role_definition.agentless_monitored_subscription[0].id)[0] : var.global_module_reference.monitored_subscription_role_definition_id
@@ -258,8 +262,15 @@ resource "azurerm_user_assigned_identity" "sidekick" {
 /* **************** Key Vault **************** 
 Define the key vault which holds integration details 
 */
+
+data "azurerm_key_vault" "existing" {
+  count = var.global && length(var.key_vault_id) > 0 ? 1 : 0
+  name = split("/", var.key_vault_id)[length(split("/", var.key_vault_id))-1]
+  resource_group_name = split("/", var.key_vault_id)[4]
+}
+
 resource "azurerm_key_vault" "lw_orchestrate" {
-  count      = var.global ? 1 : 0
+  count      = var.global  && length(var.key_vault_id) == 0 ? 1 : 0
   depends_on = [azurerm_resource_group.scanning_rg]
 
   name                       = "${local.prefix}-agentless-${local.suffix}"
@@ -282,7 +293,7 @@ id (as an env variable) to be created, while the key vault needs the container
 app managed identity to create access policies.
  */
 resource "azurerm_key_vault_access_policy" "access_for_sidekick" {
-  count = var.global ? 1 : 0
+  count = var.global && length(var.key_vault_id) == 0 ? 1 : 0
 
   key_vault_id = local.key_vault_id
   tenant_id    = local.tenant_id
@@ -297,7 +308,7 @@ resource "azurerm_key_vault_access_policy" "access_for_sidekick" {
 }
 
 resource "azurerm_key_vault_access_policy" "access_for_user" {
-  count = var.global ? 1 : 0
+  count = var.global && length(var.key_vault_id) == 0 ? 1 : 0
 
   key_vault_id = local.key_vault_id
   tenant_id    = local.tenant_id
@@ -338,7 +349,7 @@ resource "azurerm_key_vault_secret" "lw_orchestrate" {
   count = var.global ? 1 : 0
   depends_on = [
     lacework_integration_azure_agentless_scanning.lacework_cloud_account,
-    azurerm_key_vault_access_policy.access_for_user
+    azurerm_key_vault_access_policy.key_vault_user
   ]
 
   /* stores credentials used to authenticate to LW API server */


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This resolves an escalation raised by an Azure AWLS customer -- they have an org policy that restricts the creation of new key vaults, and while we provide a variable to provide an _existing_ key vault for AWLS to use, our current module ignores this variable and attempts to create a new key vault regardless.

This PR ensures that we actually use the existing key vault if configured to do so.

## How did you test this change?
The customer actually made these changes themselves, confirmed that the issue was fixed, and then provided the necessary code changes back to us.

## Issue
https://lacework.atlassian.net/browse/LINK-4201