### PR TITLE
docs: include scanning_subscription_id input for global module in examples

### DIFF
--- a/examples/custom-vnet/main.tf
+++ b/examples/custom-vnet/main.tf
@@ -58,6 +58,9 @@ module "lacework_azure_agentless_scanning_rg_and_vnet" {
   # For example, 'my-org' is the account name in 'my-org.lacework.net'.
   lacework_account = "my-org"
 
+  // specify the subscription in which AWLS will be deployed
+  scanning_subscription_id       = "abcd-1234"
+
   integration_level              = "TENANT"
   global                         = true
   custom_network                 = tolist(azurerm_virtual_network.example.subnet)[0].id

--- a/examples/subscription-multi-region/main.tf
+++ b/examples/subscription-multi-region/main.tf
@@ -7,6 +7,9 @@ module "lacework_azure_agentless_scanning_subscription_us_west" {
   # For example, 'my-org' is the account name in 'my-org.lacework.net'.
   lacework_account = "my-org"
 
+  // specify the subscription in which AWLS will be deployed
+  scanning_subscription_id       = "abcd-1234"
+
   integration_level              = "SUBSCRIPTION"
   global                         = true
   create_log_analytics_workspace = true

--- a/examples/subscription-single-region/main.tf
+++ b/examples/subscription-single-region/main.tf
@@ -5,11 +5,15 @@ module "lacework_azure_agentless_scanning_subscription_us_west" {
   # Specify your Lacework account name - only specify this in the global module.
   # For example, 'my-org' is the account name in 'my-org.lacework.net'.
   lacework_account = "my-org"
+  
+  // specify the subscription in which AWLS will be deployed
+  scanning_subscription_id       = "abcd-1234"
 
   integration_level              = "SUBSCRIPTION"
   global                         = true
   create_log_analytics_workspace = true
   region                         = "West US"
+
   // specify which subscriptions to monitor - only do this in the global module
   included_subscriptions         = ["/subscriptions/subscription-1", "/subscriptions/subscription-2"]
 }

--- a/examples/tenant-multi-region/main.tf
+++ b/examples/tenant-multi-region/main.tf
@@ -7,6 +7,9 @@ module "lacework_azure_agentless_scanning_tenant_us_west" {
   # For example, 'my-org' is the account name in 'my-org.lacework.net'.
   lacework_account = "my-org"
 
+  // specify the subscription in which AWLS will be deployed
+  scanning_subscription_id       = "abcd-1234"
+
   integration_level              = "TENANT"
   global                         = true
   create_log_analytics_workspace = true

--- a/examples/tenant-single-region/main.tf
+++ b/examples/tenant-single-region/main.tf
@@ -9,6 +9,9 @@ module "lacework_azure_agentless_scanning_single_tenant" {
   # For example, 'my-org' is the account name in 'my-org.lacework.net'.
   lacework_account = "my-org"
 
+  // specify the subscription in which AWLS will be deployed
+  scanning_subscription_id       = "abcd-1234"
+
   global                         = true
   create_log_analytics_workspace = true
   integration_level              = "tenant"


### PR DESCRIPTION
## Summary

This PR updates the examples to explicitly include the `scanning_subscription_id` input in the global module rather than assuming az-cli is properly authenticated.

## How did you test this change?

N/A - no functional change

## Issue

N/A